### PR TITLE
Improve representation of dependency strings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 changelog
 =========
 
+v0.3.1 (2022-02-27)
+-------------------
+* Better handling of PEP-508 dependencies by using the ``packaging`` module instead of the our own parsing logic - by
+  :user:`abravalheri`.
+
 v0.3.0 (2022-02-27)
 -------------------
 * Handle ``project`` section in first iteration - by :user:`gaborbernat`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ urls."Source Code" = "https://github.com/gaborbernat/pyproject-fmt"
 authors = [{ name = "Bernat Gabor", email = "gaborjbernat@gmail.com" }]
 requires-python = ">=3.7"
 dependencies = [
+  "packaging>=21.3",
   "tomlkit>=0.10",
   'typing-extensions>=3.10;python_version<"3.8"',
 ]

--- a/src/pyproject_fmt/formatter/pep508.py
+++ b/src/pyproject_fmt/formatter/pep508.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 
+from packaging.requirements import Requirement
 from tomlkit.api import string as toml_string
 from tomlkit.items import Array, String
 
@@ -30,12 +31,9 @@ def _normalize_lib(lib: str) -> str:
 
 
 def normalize_req(req: str) -> str:
-    lib, _, envs = req.partition(";")
+    lib, sep, envs = req.partition(";")
     normalized = _normalize_lib(lib)
-    envs = envs.strip()
-    if not envs:
-        return normalized
-    return f"{normalized};{envs}"
+    return str(Requirement(f"{normalized}{sep}{envs}"))
 
 
 def normalize_requires(raws: list[str]) -> list[str]:

--- a/tests/formatter/test_pep508.py
+++ b/tests/formatter/test_pep508.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-from packaging.requirements import Requirement
 
 from pyproject_fmt.formatter.pep508 import normalize_req, normalize_requires
 
@@ -46,39 +45,3 @@ def test_requires_fmt(value: str, result: list[str]) -> None:
 def test_bad_syntax_requires(char: str) -> None:
     with pytest.raises(ValueError, match=f"[{char}]" if char.strip() else None):
         normalize_req(f"{char};")
-
-
-@pytest.mark.parametrize(
-    "requirement",
-    # Examples taken from or inspired by PEP 508
-    [
-        "A",
-        "A.B-C_D",
-        "aa",
-        "name",
-        "name<=1",
-        "name>=3",
-        "name>=3,<2",
-        "name@http://foo.com",
-        "name [fred,bar] @ http://foo.com ; python_version=='2.7'",
-        "name[quux, strange];python_version<'2.7' and platform_version=='2'",
-        "name; os_name=='a' or os_name=='b'",
-        # Should parse as (a and b) or c
-        "name; os_name=='a' and os_name=='b' or os_name=='c'",
-        # Overriding precedence -> a and (b or c)
-        "name; os_name=='a' and (os_name=='b' or os_name=='c')",
-        # should parse as a or (b and c)
-        "name; os_name=='a' or os_name=='b' and os_name=='c'",
-        # Overriding precedence -> (a or b) and c
-        "name; (os_name=='a' or os_name=='b') and os_name=='c'",
-    ],
-)
-def test_format_dont_change_req_meaning(requirement):
-    # Packaging.requirements.Requirement will parse the requirement string
-    # using a proper grammar and then reconstruct it in a normalised way.
-    original = Requirement(requirement)
-    normalized = Requirement(normalize_req(requirement))
-    # By comparing the pyproject-fmt and packaging normalisation we make sure
-    # pyproject-fmt is not changing the underlying meaning/semantics of each
-    # requirement.
-    assert str(original) == str(normalized)

--- a/tests/formatter/test_pep508.py
+++ b/tests/formatter/test_pep508.py
@@ -18,9 +18,15 @@ from pyproject_fmt.formatter.pep508 import normalize_req, normalize_requires
         (
             'packaging>=20.0;python_version>"3.4"\n'
             "xonsh>=0.9.16;python_version > '3.4' and python_version != '3.9'\n"
-            "pytest-xdist>=1.31.0\n",
+            "pytest-xdist>=1.31.0\n"
+            "foo@http://foo.com\n"
+            "bar [fred,al] @ http://bat.com ;python_version=='2.7'\n"
+            "baz [quux, strange];python_version<\"2.7\" and platform_version=='2'\n",
             [
+                "foo@ http://foo.com",
                 "pytest-xdist>=1.31",
+                'bar[al,fred]@ http://bat.com ; python_version == "2.7"',
+                'baz[quux,strange]; python_version < "2.7" and platform_version == "2"',
                 'packaging>=20; python_version > "3.4"',
                 'xonsh>=0.9.16; python_version > "3.4" and python_version != "3.9"',
             ],

--- a/tests/formatter/test_pep508.py
+++ b/tests/formatter/test_pep508.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from packaging.requirements import Requirement
 
 from pyproject_fmt.formatter.pep508 import normalize_req, normalize_requires
 
@@ -45,3 +46,39 @@ def test_requires_fmt(value: str, result: list[str]) -> None:
 def test_bad_syntax_requires(char: str) -> None:
     with pytest.raises(ValueError, match=f"[{char}]" if char.strip() else None):
         normalize_req(f"{char};")
+
+
+@pytest.mark.parametrize(
+    "requirement",
+    # Examples taken from or inspired by PEP 508
+    [
+        "A",
+        "A.B-C_D",
+        "aa",
+        "name",
+        "name<=1",
+        "name>=3",
+        "name>=3,<2",
+        "name@http://foo.com",
+        "name [fred,bar] @ http://foo.com ; python_version=='2.7'",
+        "name[quux, strange];python_version<'2.7' and platform_version=='2'",
+        "name; os_name=='a' or os_name=='b'",
+        # Should parse as (a and b) or c
+        "name; os_name=='a' and os_name=='b' or os_name=='c'",
+        # Overriding precedence -> a and (b or c)
+        "name; os_name=='a' and (os_name=='b' or os_name=='c')",
+        # should parse as a or (b and c)
+        "name; os_name=='a' or os_name=='b' and os_name=='c'",
+        # Overriding precedence -> (a or b) and c
+        "name; (os_name=='a' or os_name=='b') and os_name=='c'",
+    ],
+)
+def test_format_dont_change_req_meaning(requirement):
+    # Packaging.requirements.Requirement will parse the requirement string
+    # using a proper grammar and then reconstruct it in a normalised way.
+    original = Requirement(requirement)
+    normalized = Requirement(normalize_req(requirement))
+    # By comparing the pyproject-fmt and packaging normalisation we make sure
+    # pyproject-fmt is not changing the underlying meaning/semantics of each
+    # requirement.
+    assert str(original) == str(normalized)

--- a/tests/formatter/test_pep508.py
+++ b/tests/formatter/test_pep508.py
@@ -21,8 +21,8 @@ from pyproject_fmt.formatter.pep508 import normalize_req, normalize_requires
             "pytest-xdist>=1.31.0\n",
             [
                 "pytest-xdist>=1.31",
-                'packaging>=20;python_version>"3.4"',
-                "xonsh>=0.9.16;python_version > '3.4' and python_version != '3.9'",
+                'packaging>=20; python_version > "3.4"',
+                'xonsh>=0.9.16; python_version > "3.4" and python_version != "3.9"',
             ],
         ),
         ("pytest>=6.0.0", ["pytest>=6"]),

--- a/tests/formatter/test_project.py
+++ b/tests/formatter/test_project.py
@@ -32,6 +32,24 @@ def test_project_dependencies_with_double_quotes(fmt: Fmt) -> None:
     fmt(fmt_project, start, expected)
 
 
+def test_project_dependencies_with_mixed_quotes(fmt: Fmt) -> None:
+    start = """
+    [project]
+    dependencies = [
+        "packaging>=20.0;python_version>\\"3.4\\" and python_version != '3.5'",
+        "appdirs"
+    ]
+    """
+    expected = """
+    [project]
+    dependencies = [
+      "appdirs",
+      "packaging>=20;python_version>\\"3.4\\" and python_version != '3.5'",
+    ]
+    """
+    fmt(fmt_project, start, expected)
+
+
 def test_project_description(fmt: Fmt) -> None:
     start = '[project]\ndescription=" Magical stuff\t"'
     expected = '[project]\ndescription="Magical stuff"\n'

--- a/tests/formatter/test_project.py
+++ b/tests/formatter/test_project.py
@@ -37,6 +37,7 @@ def test_project_dependencies_with_mixed_quotes(fmt: Fmt) -> None:
     [project]
     dependencies = [
         "packaging>=20.0;python_version>\\"3.4\\" and python_version != '3.5'",
+        "foobar@ git+https://weird-vcs/w/index.php?param=org'repo ; python_version == '2.7'",
         "appdirs"
     ]
     """
@@ -44,6 +45,7 @@ def test_project_dependencies_with_mixed_quotes(fmt: Fmt) -> None:
     [project]
     dependencies = [
       "appdirs",
+      "foobar@ git+https://weird-vcs/w/index.php?param=org'repo ; python_version == \\"2.7\\"",
       'packaging>=20; python_version > "3.4" and python_version != "3.5"',
     ]
     """

--- a/tests/formatter/test_project.py
+++ b/tests/formatter/test_project.py
@@ -26,7 +26,7 @@ def test_project_dependencies_with_double_quotes(fmt: Fmt) -> None:
     [project]
     dependencies = [
       "appdirs",
-      'packaging>=20;python_version>"3.4"',
+      'packaging>=20; python_version > "3.4"',
     ]
     """
     fmt(fmt_project, start, expected)
@@ -44,7 +44,7 @@ def test_project_dependencies_with_mixed_quotes(fmt: Fmt) -> None:
     [project]
     dependencies = [
       "appdirs",
-      "packaging>=20;python_version>\\"3.4\\" and python_version != '3.5'",
+      'packaging>=20; python_version > "3.4" and python_version != "3.5"',
     ]
     """
     fmt(fmt_project, start, expected)

--- a/tests/formatter/test_project.py
+++ b/tests/formatter/test_project.py
@@ -14,6 +14,24 @@ def test_project_dependencies(fmt: Fmt) -> None:
     fmt(fmt_project, start, expected)
 
 
+def test_project_dependencies_with_double_quotes(fmt: Fmt) -> None:
+    start = """
+    [project]
+    dependencies = [
+        'packaging>=20.0;python_version>"3.4"',
+        "appdirs"
+    ]
+    """
+    expected = """
+    [project]
+    dependencies = [
+      "appdirs",
+      'packaging>=20;python_version>"3.4"',
+    ]
+    """
+    fmt(fmt_project, start, expected)
+
+
 def test_project_description(fmt: Fmt) -> None:
     start = '[project]\ndescription=" Magical stuff\t"'
     expected = '[project]\ndescription="Magical stuff"\n'

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -7,9 +7,7 @@ dedent
 deps
 difflib
 dunder
-envs
 extlinks
-finditer
 fmt
 formatter
 fromfile


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #6*

**Motivation**

Hi @gaborbernat thank you very much for the great (and super useful) project!

While I was working on `ini2toml` I received some feedback in the PyPA discord with people suggesting using single quotes for the requirements that contain double quotes, to prevent `tomlkit` to escape the quotes.

The idea is to have

```toml
dependencies = [
  'packaging>=20.0;python_version>"3.4"',
]
```

instead of:

```toml
dependencies = [
  "packaging>=20.0;python_version>\"3.4\"",
]
```

(this is more or less the same approach `black` takes, with the difference that literal strings in TOML are more limited than the ones in Python).

Would you consider incorporating this style to `pyproject-fmt`?

**Describe your changes**

- Changed `project_fmt.formatter.pep508.normalize_requires` to attempt using TOML literal strings when the value of the requirement contains double quotes.
- It will revert back to basic strings if the requirement value contains invalid chars for the literal representation.

**Testing performed**
- Added `test_project_dependencies_with_double_quotes` to capture the expectations mentioned about (in **Motivation**).
