### PR TITLE
Experiment: Attempt to normalise all quotes inside PEP 508 requirements.

### DIFF
--- a/src/pyproject_fmt/formatter/pep508.py
+++ b/src/pyproject_fmt/formatter/pep508.py
@@ -8,6 +8,7 @@ from .util import ArrayEntries, sorted_array
 
 BASE_NAME_REGEX = re.compile(r"[^!=><~\s@]+")
 REQ_REGEX = re.compile(r"(===|==|!=|~=|>=?|<=?|@)\s*([^,]+)")
+SINGLE_QUOTE_REGEX = re.compile(r"'([^']*)'")
 
 
 def _req_base(lib: str) -> str:
@@ -34,6 +35,9 @@ def normalize_req(req: str) -> str:
     envs = envs.strip()
     if not envs:
         return normalized
+    # Inspired by `packaging`, let's make all contained strings double-quoted.
+    # This avoids the having mixed quotes inside the same requirement
+    envs = SINGLE_QUOTE_REGEX.sub(r'"\1"', envs)
     return f"{normalized};{envs}"
 
 

--- a/tests/formatter/test_pep508.py
+++ b/tests/formatter/test_pep508.py
@@ -18,11 +18,17 @@ from pyproject_fmt.formatter.pep508 import normalize_req, normalize_requires
         (
             'packaging>=20.0;python_version>"3.4"\n'
             "xonsh>=0.9.16;python_version > '3.4' and python_version != '3.9'\n"
-            "pytest-xdist>=1.31.0\n",
+            "pytest-xdist>=1.31.0\n"
+            "foo@http://foo.com\n"
+            "bar [fred,al] @ http://bat.com ; python_version=='2.7'\n"
+            "baz [quux, strange];python_version<\"2.7\" and platform_version=='2'\n",
             [
+                'foo [fred,bar] @ http://foo.com; python_version=="2.7"',
                 "pytest-xdist>=1.31",
+                'bar [fred,al] @ http://bat.com ;python_version=="2.7"',
+                'baz [quux, strange];python_version<"2.7" and platform_version=="2"',
                 'packaging>=20;python_version>"3.4"',
-                "xonsh>=0.9.16;python_version > '3.4' and python_version != '3.9'",
+                'xonsh>=0.9.16;python_version > "3.4" and python_version != "3.9"',
             ],
         ),
         ("pytest>=6.0.0", ["pytest>=6"]),


### PR DESCRIPTION
This is a follow up on the discussion in: https://github.com/gaborbernat/pyproject-fmt/pull/2#discussion_r814893679

**Describe your changes**
- Added a naïve regular expression for replacing single quotes with double quotes.
  * Please note that it could have been done the other way around as well (replacing double quotes with single quotes). I just followed the same behaviour that `packaging` uses. 

**Testing performed**
- In the PEP 508 tests, I have added a bunch of complex examples inspired by the [PEP text](https://www.python.org/dev/peps/pep-0508/) to make sure this approach works.

### Tests seem to be failing due to other problems

With the added examples from the PEP, `pytest` fails and displays the following differences:
```diff
  [
-  'foo [fred,bar] @ http://foo.com; python_version=="2.7"',
+  'foo@http://foo.com',
   'pytest-xdist>=1.31',
-  'bar [fred,al] @ http://bat.com ;python_version=="2.7"',
?      ----------- -
+  'bar@http://bat.com ;python_version=="2.7"',
-  'baz [quux, strange];python_version<"2.7" and platform_version=="2"',
?      ----------------
+  'baz;python_version<"2.7" and platform_version=="2"',
   'packaging>=20;python_version>"3.4"',
   'xonsh>=0.9.16;python_version > "3.4" and python_version != "3.9"',
]
```

Here it seems that the quote normalisation is working well (I don't know if there are more complex scenarios not being tested), however the current code *is not be able to handle extras correctly* and ends up removing them.