### PR TITLE
Add programmatic API

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,3 +41,11 @@ Command line interface
 
    self
    changelog
+
+Python API
+----------
+
+.. autofunction:: pyproject_fmt::format_pyproject
+
+.. autoclass:: pyproject_fmt::PyProjectFmtNamespace
+   :members:

--- a/src/pyproject_fmt/__init__.py
+++ b/src/pyproject_fmt/__init__.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from ._version import version as __version__
+from .cli import PyProjectFmtNamespace
+from .formatter import format_pyproject
 
 __all__ = [
     "__version__",
+    "format_pyproject",
+    "PyProjectFmtNamespace",
 ]

--- a/src/pyproject_fmt/__main__.py
+++ b/src/pyproject_fmt/__main__.py
@@ -25,14 +25,14 @@ def color_diff(diff: Iterable[str]) -> Iterable[str]:
 
 def run(args: Sequence[str] | None = None) -> int:
     opts = cli_args(sys.argv[1:] if args is None else args)
-    formatted = format_pyproject(opts)
     toml = opts.pyproject_toml
-    before = toml.read_text()
+    before = toml.read_text(encoding="utf-8")
+    formatted = format_pyproject(before, opts.format_options)
     changed = before != formatted
     if opts.stdout:  # stdout just prints new format to stdout
         print(formatted, end="")
     else:
-        toml.write_text(formatted)
+        toml.write_text(formatted, encoding="utf-8")
         try:
             name = str(toml.relative_to(Path.cwd()))
         except ValueError:

--- a/src/pyproject_fmt/__main__.py
+++ b/src/pyproject_fmt/__main__.py
@@ -27,7 +27,7 @@ def run(args: Sequence[str] | None = None) -> int:
     opts = cli_args(sys.argv[1:] if args is None else args)
     toml = opts.pyproject_toml
     before = toml.read_text(encoding="utf-8")
-    formatted = format_pyproject(before, opts.format_options)
+    formatted = format_pyproject(before, opts)
     changed = before != formatted
     if opts.stdout:  # stdout just prints new format to stdout
         print(formatted, end="")

--- a/src/pyproject_fmt/cli.py
+++ b/src/pyproject_fmt/cli.py
@@ -13,16 +13,11 @@ class PyProjectFmtNamespace(Namespace):
     """Number of indentation spaces used for formatting"""
 
 
-class PyProjectFmtCliNamespace(Namespace):
+class PyProjectFmtCliNamespace(PyProjectFmtNamespace):
     """Options for pyproject-fmt tool"""
 
     pyproject_toml: Path
     stdout: bool
-    indent = 2
-
-    @property
-    def format_options(self) -> PyProjectFmtNamespace:
-        return PyProjectFmtNamespace(indent=self.indent)
 
 
 def pyproject_toml_path_creator(argument: str) -> Path:

--- a/src/pyproject_fmt/cli.py
+++ b/src/pyproject_fmt/cli.py
@@ -7,11 +7,22 @@ from typing import Sequence
 
 
 class PyProjectFmtNamespace(Namespace):
+    """Options for the pyproject_fmt library"""
+
+    indent = 2
+    """Number of indentation spaces used for formatting"""
+
+
+class PyProjectFmtCliNamespace(Namespace):
     """Options for pyproject-fmt tool"""
 
     pyproject_toml: Path
     stdout: bool
     indent = 2
+
+    @property
+    def format_options(self) -> PyProjectFmtNamespace:
+        return PyProjectFmtNamespace(indent=self.indent)
 
 
 def pyproject_toml_path_creator(argument: str) -> Path:
@@ -40,7 +51,7 @@ def _build_cli() -> ArgumentParser:
     return parser
 
 
-def cli_args(args: Sequence[str]) -> PyProjectFmtNamespace:
+def cli_args(args: Sequence[str]) -> PyProjectFmtCliNamespace:
     """
     Load the tools options.
 
@@ -48,7 +59,7 @@ def cli_args(args: Sequence[str]) -> PyProjectFmtNamespace:
     :return: the parsed options
     """
     parser = _build_cli()
-    return parser.parse_args(namespace=PyProjectFmtNamespace(), args=args)
+    return parser.parse_args(namespace=PyProjectFmtCliNamespace(), args=args)
 
 
 __all__ = [

--- a/src/pyproject_fmt/cli.py
+++ b/src/pyproject_fmt/cli.py
@@ -7,7 +7,7 @@ from typing import Sequence
 
 
 class PyProjectFmtNamespace(Namespace):
-    """Options for the pyproject_fmt library"""
+    """Options for the ``pyproject_fmt`` library"""
 
     indent = 2
     """Number of indentation spaces used for formatting"""

--- a/src/pyproject_fmt/formatter/__init__.py
+++ b/src/pyproject_fmt/formatter/__init__.py
@@ -14,6 +14,22 @@ def _perform(parsed: TOMLDocument, opts: PyProjectFmtNamespace) -> None:
 
 
 def format_pyproject(text: str, opts: PyProjectFmtNamespace) -> str:
+    r"""
+    Format a string with the equivalent content of a ``pyproject.toml`` file.
+
+    Usage:
+
+    >>> from pyproject_fmt import PyProjectFmtNamespace, format_pyproject
+    >>> text = '[project]\nname = "myproj"\nversion = "0.1.1"'
+    >>> opts = PyProjectFmtNamespace(indent=2)
+    >>> format_pyproject(text, opts)
+    '[project]\nname = "myproj"\nversion = "0.1.1"\n'
+
+    :param text: the contents of the TOML file as an UTF-8 string
+    :param opts: object with the formatting options
+    :return: the formatted TOML string that can be saved to a ``pyproject.toml`` file.
+    """
+
     parsed: TOMLDocument = parse(text)
     _perform(parsed, opts)
     result = parsed.as_string().rstrip("\n")

--- a/src/pyproject_fmt/formatter/__init__.py
+++ b/src/pyproject_fmt/formatter/__init__.py
@@ -13,8 +13,7 @@ def _perform(parsed: TOMLDocument, opts: PyProjectFmtNamespace) -> None:
     fmt_project(parsed, opts)
 
 
-def format_pyproject(opts: PyProjectFmtNamespace) -> str:
-    text = opts.pyproject_toml.read_text()
+def format_pyproject(text: str, opts: PyProjectFmtNamespace) -> str:
     parsed: TOMLDocument = parse(text)
     _perform(parsed, opts)
     result = parsed.as_string().rstrip("\n")

--- a/tests/formatter/conftest.py
+++ b/tests/formatter/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 from textwrap import dedent
 from typing import Callable
 
@@ -14,13 +13,10 @@ from tests import Fmt
 
 
 @pytest.fixture()
-def fmt(tmp_path: Path, mocker: MockerFixture) -> Fmt:
+def fmt(mocker: MockerFixture) -> Fmt:
     def _func(formatter: Callable[[TOMLDocument, PyProjectFmtNamespace], None], start: str, expected: str) -> None:
         mocker.patch("pyproject_fmt.formatter._perform", formatter)
-        toml = tmp_path / "a.toml"
-        toml.write_text(dedent(start))
-        opts = PyProjectFmtNamespace(pyproject_toml=tmp_path / "a.toml")
-        result = format_pyproject(opts)
+        result = format_pyproject(dedent(start), PyProjectFmtNamespace())
 
         expected = dedent(expected)
         assert result == expected

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ extras =
     test
 commands =
     python -m pytest {tty:--color=yes} {posargs: \
+      --doctest-modules \
       --junitxml {toxworkdir}{/}junit.{envname}.xml --cov {envsitepackagesdir}{/}pyproject_fmt \
       --cov {toxinidir}{/}tests --cov-fail-under=100 \
       --cov-config=pyproject.toml --no-cov-on-fail --cov-report term-missing:skip-covered --cov-context=test \


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #3*

This PR attempts to refactor a bit the existing code so that a Python API is exposed (and `pyproject-fmt` can be used as a library).

**Describe your changes**
- The existing `PyProjectFmtNamespace` class was separated in 2 different classes:
  - `PyProjectFmtCliNamespace` that is used only at the CLI layer and
  - (the new) `PyProjectFmtNamespace`, that is used by all internal functions (I kept the same name here to minimise the size of the changes).
- The signature of `format_pyproject` was changed, allowing it to be easier to use programmatically. Instead of requiring a path to the `pyproject.toml` file, now it allows the contents of the TOML file to be passed directly as a string. 

**Testing performed**
The tests were adjusted accordingly to use the changed Python API.

**Additional context**
In #3 the project author asked about adding documentation via Sphinx.
This change is not added to this PR directly for the sake of keeping the diff small and easier to review. However a follow up change that adds a minimal skeleton for using Sphinx to generate documentation was already worked on, and is available at: https://github.com/abravalheri/pyproject-fmt/pull/1
