### PR TITLE
Fix invalid newline inside inline-table

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 changelog
 =========
 
+v0.3.2 (2022-03-01)
+-------------------
+* Fix invalid newline inside inline-table - by :user:`abravalheri`.
+
 v0.3.1 (2022-02-27)
 -------------------
 * Better handling of PEP-508 dependencies by using the ``packaging`` module instead of the our own parsing logic - by

--- a/src/pyproject_fmt/formatter/build_system.py
+++ b/src/pyproject_fmt/formatter/build_system.py
@@ -15,7 +15,7 @@ def fmt_build_system(parsed: TOMLDocument, conf: Config) -> None:
     if system is not None:
         normalize_pep508_array(cast(Optional[Array], system.get("requires")), conf.indent)
         sorted_array(cast(Optional[Array], system.get("backend-path")), indent=conf.indent)
-        order_keys(system.value.body, ("build-backend", "requires", "backend-path"))
+        order_keys(system, ("build-backend", "requires", "backend-path"))
 
 
 __all__ = [

--- a/src/pyproject_fmt/formatter/project.py
+++ b/src/pyproject_fmt/formatter/project.py
@@ -30,18 +30,18 @@ def fmt_project(parsed: TOMLDocument, conf: Config) -> None:
         opt_deps = cast(Table, project["optional-dependencies"])
         for value in opt_deps.values():
             normalize_pep508_array(cast(Array, value), conf.indent)
-        order_keys(opt_deps.value.body, (), sort_key=lambda k: k[0])
+        order_keys(opt_deps, (), sort_key=lambda k: k[0])
 
     for of_type in ("scripts", "gui-scripts", "entry-points", "urls"):
         if of_type in project:
             table = cast(Table, project[of_type])
-            order_keys(table.value.body, (), sort_key=lambda k: k[0])
+            order_keys(table, (), sort_key=lambda k: k[0])
 
     if "entry-points" in project:  # order entry points sub-table
         entry_points = cast(Table, project["entry-points"])
-        order_keys(entry_points.value.body, (), sort_key=lambda k: k[0])
+        order_keys(entry_points, (), sort_key=lambda k: k[0])
         for entry_point in entry_points.values():
-            order_keys(entry_point.value.body, (), sort_key=lambda k: k[0])
+            order_keys(entry_point, (), sort_key=lambda k: k[0])
 
     # license: Optional[Union[str, LicenseTableLegacy]]
     # license_files: Optional[LicenseFilesTable] = Field(alias="license-files")
@@ -51,7 +51,7 @@ def fmt_project(parsed: TOMLDocument, conf: Config) -> None:
     # handle readme table
 
     order_keys(
-        project.value.body,
+        project,
         (
             "name",
             "version",

--- a/src/pyproject_fmt/formatter/util.py
+++ b/src/pyproject_fmt/formatter/util.py
@@ -4,7 +4,17 @@ import sys
 from dataclasses import dataclass, field
 from typing import Any, Callable, Sequence
 
-from tomlkit.items import Array, Comment, Item, Key, String, Trivia, Whitespace
+from tomlkit.items import (
+    AbstractTable,
+    Array,
+    Comment,
+    Item,
+    Key,
+    String,
+    Table,
+    Trivia,
+    Whitespace,
+)
 
 if sys.version_info >= (3, 8):  # pragma: no cover (py38+)
     from typing import Protocol
@@ -23,10 +33,11 @@ class SupportsDunderGT(Protocol):
 
 
 def order_keys(
-    body: list[tuple[Key | None, Item]],
+    table: AbstractTable,
     to_pin: Sequence[str] | None = None,
     sort_key: None | Callable[[tuple[str, tuple[Key, Item]]], SupportsDunderLT | SupportsDunderGT] = None,
 ) -> None:
+    body = table.value.body
     entries = {i.key: (i, v) for (i, v) in body if isinstance(i, Key)}
     body.clear()
 
@@ -39,7 +50,9 @@ def order_keys(
         body.extend(entries.values())
     else:
         body.extend(v for k, v in sorted(entries.items(), key=sort_key))
-    body.append((None, Whitespace("\n")))  # add trailing newline to separate
+
+    if isinstance(table, Table):
+        body.append((None, Whitespace("\n")))  # add trailing newline to separate
 
 
 @dataclass

--- a/tests/formatter/test_project.py
+++ b/tests/formatter/test_project.py
@@ -101,9 +101,7 @@ def test_entry_points(fmt: Fmt) -> None:
     """
     expected = """
     [project.entry-points]
-    alpha = {"A.A" = "a",B = "b"
-    }
-    beta = {C = "c",D = "d"
-    }
+    alpha = {"A.A" = "a",B = "b"}
+    beta = {C = "c",D = "d"}
     """
     fmt(fmt_project, start, expected)


### PR DESCRIPTION
Hello, this is a possible approach to fix #11.

The approach I took here was to pass the entire table object to the `order_keys` function, so it can be inspected to determine when it is appropriate (or not) to add an empty line.

I understand that the changes here might not be exactly what you have in mind, so please feel free to close this PR or ask for changes, I will be happy to implement them.