### PR TITLE
feat: support multiple "pyproject.toml" files

### DIFF
--- a/src/pyproject_fmt/cli.py
+++ b/src/pyproject_fmt/cli.py
@@ -16,16 +16,20 @@ from pyproject_fmt.formatter.config import DEFAULT_INDENT, Config
 class PyProjectFmtNamespace(Namespace):
     """Options for pyproject-fmt tool"""
 
-    pyproject_toml: Path
+    pyproject_tomls: list[Path]
     stdout: bool
     indent: int
 
     @property
-    def as_config(self) -> Config:
-        return Config(
-            toml=self.pyproject_toml.read_text(encoding="utf-8"),
-            indent=self.indent,
-        )
+    def as_configs(self) -> list[Config]:
+        return [
+            Config(
+                pyproject_toml=pyproject_toml,
+                toml=pyproject_toml.read_text(encoding="utf-8"),
+                indent=self.indent,
+            )
+            for pyproject_toml in self.pyproject_tomls
+        ]
 
 
 def pyproject_toml_path_creator(argument: str) -> Path:
@@ -51,7 +55,9 @@ def _build_cli() -> ArgumentParser:
     msg = "print the formatted text to the stdout (instead of update in-place)"
     parser.add_argument("-s", "--stdout", action="store_true", help=msg)
     parser.add_argument("--indent", type=int, default=DEFAULT_INDENT, help="number of spaces to indent")
-    parser.add_argument("pyproject_toml", type=pyproject_toml_path_creator, help="pyproject.toml file to format")
+    parser.add_argument(
+        "pyproject_tomls", nargs="+", type=pyproject_toml_path_creator, help="pyproject.toml file(s) to format"
+    )
     return parser
 
 

--- a/src/pyproject_fmt/formatter/config.py
+++ b/src/pyproject_fmt/formatter/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 if sys.version_info >= (3, 8):  # pragma: no cover (py38+)
     from typing import Final
@@ -18,6 +19,7 @@ class Config:
 
     toml: str  #: the text to format
     indent: int = DEFAULT_INDENT  #: indentation to apply
+    pyproject_toml: Path | None = None  # Only necessary when writing
 
 
 __all__ = [

--- a/src/pyproject_fmt/formatter/config.py
+++ b/src/pyproject_fmt/formatter/config.py
@@ -17,9 +17,9 @@ DEFAULT_INDENT: Final[int] = 2  #: default indentation level
 class Config:
     """Configuration flags for the formatting."""
 
+    pyproject_toml: Path
     toml: str  #: the text to format
     indent: int = DEFAULT_INDENT  #: indentation to apply
-    pyproject_toml: Path | None = None  # Only necessary when writing
 
 
 __all__ = [

--- a/tests/formatter/conftest.py
+++ b/tests/formatter/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from textwrap import dedent
 from typing import Callable
 
@@ -16,7 +17,7 @@ from tests import Fmt
 def fmt(mocker: MockerFixture) -> Fmt:
     def _func(formatter: Callable[[TOMLDocument, Config], None], start: str, expected: str) -> None:
         mocker.patch("pyproject_fmt.formatter._perform", formatter)
-        opts = Config(toml=dedent(start))
+        opts = Config(pyproject_toml=Path(), toml=dedent(start))
         result = format_pyproject(opts)
 
         expected = dedent(expected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,17 @@ def test_cli_pyproject_toml_ok(tmp_path: Path) -> None:
     path = tmp_path / "tox.ini"
     path.write_text("")
     result = cli_args([str(path)])
-    assert result.pyproject_toml == path
+    assert result.pyproject_tomls == [path]
+
+
+def test_cli_pyproject_tomls_ok(tmp_path: Path) -> None:
+    paths = []
+    for filename in ("tox.ini", "tox2.ini", "tox3.ini"):
+        path = tmp_path / filename
+        path.write_text("")
+        paths.append(path)
+    result = cli_args([*map(str, paths)])
+    assert result.pyproject_tomls == paths
 
 
 def test_cli_pyproject_toml_not_exists(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -22,7 +32,7 @@ def test_cli_pyproject_toml_not_exists(tmp_path: Path, capsys: pytest.CaptureFix
     assert context.value.code != 0
     out, err = capsys.readouterr()
     assert not out
-    assert "argument pyproject_toml: path does not exist" in err
+    assert "argument pyproject_tomls: path does not exist" in err
 
 
 def test_cli_pyproject_toml_not_file(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -31,7 +41,7 @@ def test_cli_pyproject_toml_not_file(tmp_path: Path, capsys: pytest.CaptureFixtu
     assert context.value.code != 0
     out, err = capsys.readouterr()
     assert not out
-    assert "argument pyproject_toml: path is not a file" in err
+    assert "argument pyproject_tomls: path is not a file" in err
 
 
 @pytest.mark.parametrize(("flag", "error"), [(S_IREAD, "write"), (S_IWRITE, "read")])
@@ -50,7 +60,7 @@ def test_cli_pyproject_toml_permission_fail(
     assert context.value.code != 0
     out, err = capsys.readouterr()
     assert not out
-    assert f"argument pyproject_toml: cannot {error} path" in err
+    assert f"argument pyproject_tomls: cannot {error} path" in err
 
 
 def test_pyproject_toml_resolved(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -58,4 +68,4 @@ def test_pyproject_toml_resolved(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     path = tmp_path / "tox.ini"
     path.write_text("")
     result = cli_args(["tox.ini"])
-    assert result.pyproject_toml == path
+    assert result.pyproject_tomls == [path]

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -20,4 +20,5 @@ skipif
 tofile
 toml
 tomlkit
+tomls
 typehints


### PR DESCRIPTION
Fixes #45

I tried to keep variable names and style consistent with the other code. `tox` for `3.7` and `3.10` pass locally

Let me know if there is anything you would like me to change, or feel free to make changes!