### PR TITLE
Update version of `pyproject-fmt` in example pre-commit hook in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ See :gh:`pre-commit/pre-commit` for instructions, sample ``.pre-commit-config.ya
 .. code-block:: yaml
 
     - repo: https://github.com/tox-dev/pyproject-fmt
-      rev: "0.1.0"
+      rev: "0.4.1"
       hooks:
         - id: pyproject-fmt
 


### PR DESCRIPTION
This PR changes the version of `pyproject-fmt` used in the sample pre-commit hook to the most recent release.

Thank you for making this awesome tool!