### PR TITLE
Only write to file if changed

### DIFF
--- a/src/pyproject_fmt/__main__.py
+++ b/src/pyproject_fmt/__main__.py
@@ -34,7 +34,8 @@ def run(args: Sequence[str] | None = None) -> int:
         if opts.stdout:  # stdout just prints new format to stdout
             print(formatted, end="")
         else:
-            config.pyproject_toml.write_text(formatted, encoding="utf-8")
+            if before != formatted:
+                config.pyproject_toml.write_text(formatted, encoding="utf-8")
             try:
                 name = str(config.pyproject_toml.relative_to(Path.cwd()))
             except ValueError:


### PR DESCRIPTION
Like tox-ini-fmt, let's only write to the file if the content has changed:

https://github.com/tox-dev/tox-ini-fmt/blob/371d5d59738f8f1fc7c8ebf0b5efbc71788bec1f/src/tox_ini_fmt/__main__.py#L40-L42

# Before

```console
$ touch -t 202301011200 pyproject.toml
$ date -r pyproject.toml
Sun Jan  1 12:00:00 EET 2023
$ pyproject-fmt pyproject.toml
no change for pyproject.toml
$ date -r pyproject.toml
Thu Jan 19 16:03:09 EET 2023
```

# After

```console
$ date -r pyproject.toml
Sun Jan  1 12:00:00 EET 2023
$ pyproject-fmt pyproject.toml
no change for pyproject.toml
$ date -r pyproject.toml
Sun Jan  1 12:00:00 EET 2023
```

