### PR TITLE
Exclude bots from generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
Like https://github.com/tox-dev/tox-ini-fmt/pull/120, will help releases like https://github.com/tox-dev/pyproject-fmt/releases/tag/0.4.0.