### PR TITLE
Sort classifiers and respect `--indent`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
+  "natsort",
   "packaging>=23",
   "tomlkit>=0.11.6",
   'typing-extensions>=4.5; python_version < "3.8"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "natsort",
+  "natsort>=8.3.1",
   "packaging>=23",
   "tomlkit>=0.11.6",
   'typing-extensions>=4.5; python_version < "3.8"',

--- a/src/pyproject_fmt/formatter/project.py
+++ b/src/pyproject_fmt/formatter/project.py
@@ -25,6 +25,7 @@ def fmt_project(parsed: TOMLDocument, conf: Config) -> None:
 
     sorted_array(cast(Optional[Array], project.get("keywords")), indent=conf.indent)
     sorted_array(cast(Optional[Array], project.get("dynamic")), indent=conf.indent)
+    sorted_array(cast(Optional[Array], project.get("classifiers")), indent=conf.indent, custom_sort="natsort")
 
     normalize_pep508_array(cast(Optional[Array], project.get("dependencies")), conf.indent)
     if "optional-dependencies" in project:

--- a/src/pyproject_fmt/formatter/util.py
+++ b/src/pyproject_fmt/formatter/util.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Callable, Sequence
 
+from natsort import natsorted
 from tomlkit.container import OutOfOrderTableProxy
 from tomlkit.items import (
     AbstractTable,
@@ -75,7 +76,10 @@ class ArrayEntries:
 
 
 def sorted_array(
-    array: Array | None, indent: int, key: Callable[[ArrayEntries], str] = lambda e: str(e.text).lower()
+    array: Array | None,
+    indent: int,
+    key: Callable[[ArrayEntries], str] = lambda e: str(e.text).lower(),
+    custom_sort: str | None = None,
 ) -> None:
     if array is None:
         return
@@ -94,7 +98,8 @@ def sorted_array(
     indent_text = " " * indent
     for start_entry in start:
         body.append(_ArrayItemGroup(indent=Whitespace(f"\n{indent_text}"), comment=start_entry))
-    for element in sorted(entries, key=key):
+    sort_method = natsorted if custom_sort == "natsort" else sorted
+    for element in sort_method(entries, key=key):
         if element.comments:
             com = " ".join(i.trivia.comment[1:].strip() for i in element.comments)
             comment = Comment(Trivia(comment=f" # {com}", trail=""))

--- a/src/pyproject_fmt/formatter/util.py
+++ b/src/pyproject_fmt/formatter/util.py
@@ -41,7 +41,7 @@ T = TypeVar("T")
 
 
 class SortingFunction(Protocol[T]):
-    def __call__(self, seq: Iterable[T], /, key: Callable[[T], SupportsDunderLT]) -> list[T]:  # noqa: U100
+    def __call__(self, __seq: Iterable[T], key: Callable[[T], SupportsDunderLT]) -> list[T]:  # noqa: U100, U101
         ...
 
 

--- a/tests/formatter/test_project.py
+++ b/tests/formatter/test_project.py
@@ -18,6 +18,40 @@ def test_project_name(fmt: Fmt, value: str) -> None:
     fmt(fmt_project, value, '[project]\nname="a-b"\n')
 
 
+def test_project_classifiers(fmt: Fmt) -> None:
+    start = """
+    [project]
+    classifiers = [
+      "Operating System :: OS Independent",
+      "Programming Language :: Python",
+      "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3 :: Only",
+      "License :: OSI Approved :: MIT License",
+      "Programming Language :: Python :: 3.7",
+      "Programming Language :: Python :: 3.8",
+      "License :: OSI Approved :: MIT License",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.11",
+    ]
+    """
+    expected = """
+    [project]
+    classifiers = [
+      "License :: OSI Approved :: MIT License",
+      "License :: OSI Approved :: MIT License",
+      "Operating System :: OS Independent",
+      "Programming Language :: Python",
+      "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.7",
+      "Programming Language :: Python :: 3.8",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.11",
+    ]
+    """
+    fmt(fmt_project, start, expected)
+
+
 def test_project_dependencies(fmt: Fmt) -> None:
     start = '[project]\ndependencies=["pytest","pytest-cov",]'
     expected = '[project]\ndependencies=[\n  "pytest",\n  "pytest-cov",\n]\n'

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -11,6 +11,8 @@ intersphinx
 iread
 iwrite
 mkfifo
+natsort
+natsorted
 nitpicky
 pep508
 py38


### PR DESCRIPTION
Right now, pyproject-fmt indents most sections using the `--indent` value (default: 2 spaces), but not the project `classifiers` section.

For example, if I first modify this project's `pyproject.toml` to use four space, then run `pyproject-fmt pyproject.toml`, they're all fixed to two spaces, except for the classifiers:

```diff
--- pyproject.toml

+++ pyproject.toml

@@ -1,8 +1,8 @@

 [build-system]
 build-backend = "hatchling.build"
 requires = [
-    "hatch-vcs>=0.3",
-    "hatchling>=1.13",
+  "hatch-vcs>=0.3",
+  "hatchling>=1.13",
 ]

 [project]
@@ -10,8 +10,8 @@

 description = "Format your pyproject.toml file"
 readme = "README.md"
 keywords = [
-    "format",
-    "pyproject",
+  "format",
+  "pyproject",
 ]
 license.file = "LICENSE.txt"
 authors = [{ name = "Bernat Gabor", email = "gaborjbernat@gmail.com" }]
@@ -28,25 +28,25 @@

     "Programming Language :: Python :: 3.11",
 ]
 dynamic = [
-    "version",
+  "version",
 ]
 dependencies = [
-    "packaging>=23",
-    "tomlkit>=0.11.6",
-    'typing-extensions>=4.5; python_version < "3.8"',
+  "packaging>=23",
+  "tomlkit>=0.11.6",
+  'typing-extensions>=4.5; python_version < "3.8"',
 ]
 optional-dependencies.docs = [
-    "furo>=2022.12.7",
-    "sphinx>=6.1.3",
-    "sphinx-argparse-cli>=1.11",
-    "sphinx-autodoc-typehints!=1.23.4,>=1.22",
-    "sphinx-copybutton>=0.5.1",
+  "furo>=2022.12.7",
+  "sphinx>=6.1.3",
+  "sphinx-argparse-cli>=1.11",
+  "sphinx-autodoc-typehints!=1.23.4,>=1.22",
+  "sphinx-copybutton>=0.5.1",
 ]
 optional-dependencies.test = [
-    "covdefaults>=2.3",
-    "pytest>=7.2.2",
-    "pytest-cov>=4",
-    "pytest-mock>=3.10",
+  "covdefaults>=2.3",
+  "pytest>=7.2.2",
+  "pytest-cov>=4",
+  "pytest-mock>=3.10",
 ]
 urls."Bug Tracker" = "https://github.com/tox-dev/pyproject-fmt/issues"
 urls."Changelog" = "https://github.com/tox-dev/pyproject-fmt/releases"
```


With this PR, the classifiers are also sorted and indented:

```diff
--- pyproject.toml

+++ pyproject.toml

@@ -1,8 +1,8 @@

 [build-system]
 build-backend = "hatchling.build"
 requires = [
-    "hatch-vcs>=0.3",
-    "hatchling>=1.13",
+  "hatch-vcs>=0.3",
+  "hatchling>=1.13",
 ]

 [project]
@@ -10,44 +10,44 @@

 description = "Format your pyproject.toml file"
 readme = "README.md"
 keywords = [
-    "format",
-    "pyproject",
+  "format",
+  "pyproject",
 ]
 license.file = "LICENSE.txt"
 authors = [{ name = "Bernat Gabor", email = "gaborjbernat@gmail.com" }]
 requires-python = ">=3.7"
 classifiers = [
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
 ]
 dynamic = [
-    "version",
+  "version",
 ]
 dependencies = [
-    "natsort",
-    "packaging>=23",
-    "tomlkit>=0.11.6",
-    'typing-extensions>=4.5; python_version < "3.8"',
+  "natsort",
+  "packaging>=23",
+  "tomlkit>=0.11.6",
+  'typing-extensions>=4.5; python_version < "3.8"',
 ]
 optional-dependencies.docs = [
-    "furo>=2022.12.7",
-    "sphinx>=6.1.3",
-    "sphinx-argparse-cli>=1.11",
-    "sphinx-autodoc-typehints!=1.23.4,>=1.22",
-    "sphinx-copybutton>=0.5.1",
+  "furo>=2022.12.7",
+  "sphinx>=6.1.3",
+  "sphinx-argparse-cli>=1.11",
+  "sphinx-autodoc-typehints!=1.23.4,>=1.22",
+  "sphinx-copybutton>=0.5.1",
 ]
 optional-dependencies.test = [
-    "covdefaults>=2.3",
-    "pytest>=7.2.2",
-    "pytest-cov>=4",
-    "pytest-mock>=3.10",
+  "covdefaults>=2.3",
+  "pytest>=7.2.2",
+  "pytest-cov>=4",
+  "pytest-mock>=3.10",
 ]
 urls."Bug Tracker" = "https://github.com/tox-dev/pyproject-fmt/issues"
 urls."Changelog" = "https://github.com/tox-dev/pyproject-fmt/releases"
```

Note we need to use something like https://github.com/SethMMorton/natsort for the classifiers, because they can include version numbers, and the basic `sorted` gives:

```diff
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
 ]
```

