### PR TITLE
GitHub Actions: Autoupgrade to Py3.12 production release

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         py:
-          - "3.12.0-rc.1"
+          - "3.12"
           - "3.11"
           - "3.10"
           - "3.9"
@@ -35,6 +35,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.py }}
+          allow-prereleases: true
       - name: Pick environment to run
         run: |
           import codecs; import os; import sys


### PR DESCRIPTION
https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#allow-pre-releases
The test runs on `3.12.0-rc.1` instead of the current `3.12.0-rc.3` today and `3.12.0` production release tomorrow.