### PR TITLE
Fix generating Python version classifiers based on `python-requires`

### DIFF
--- a/src/pyproject_fmt/formatter/project.py
+++ b/src/pyproject_fmt/formatter/project.py
@@ -23,6 +23,18 @@ _PY_MIN_VERSION: int = 7
 _PY_MAX_VERSION: int = 12
 
 
+def _get_min_version_specifier(specifiers: SpecifierSet) -> int:
+    min_version: list[int] = [_PY_MIN_VERSION]
+
+    for specifier in specifiers:
+        if specifier.operator == ">=":
+            min_version.append(Version(specifier.version).minor)
+        if specifier.operator == ">":
+            min_version.append(Version(specifier.version).minor + 1)
+
+    return min(min_version)
+
+
 def _get_max_version_specifier(specifiers: SpecifierSet) -> int | None:
     max_version: list[int] = []
 
@@ -68,12 +80,13 @@ def _add_py_classifiers(project: Table) -> None:
 
     specifiers = SpecifierSet(requires)
 
+    min_version = _get_min_version_specifier(specifiers)
     max_version = _get_max_version_specifier(specifiers)
     if not max_version:
         max_version = _get_max_version_tox()
 
     allowed_versions = list(
-        specifiers.filter(f"3.{v}" for v in range(_PY_MIN_VERSION, max_version + 1)),
+        specifiers.filter(f"3.{v}" for v in range(min_version, max_version + 1)),
     )
 
     add = [f"Programming Language :: Python :: {v}" for v in allowed_versions]

--- a/tests/formatter/test_project.py
+++ b/tests/formatter/test_project.py
@@ -187,13 +187,35 @@ def test_classifier_lt(fmt: Fmt) -> None:
 def test_classifier_gt(fmt: Fmt) -> None:
     start = """
     [project]
-    requires-python = ">=3.7"
+    requires-python = ">3.6"
     """
     expected = """
     [project]
-    requires-python = ">=3.7"
+    requires-python = ">3.6"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.7",
+      "Programming Language :: Python :: 3.8",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.11",
+      "Programming Language :: Python :: 3.12",
+    ]
+    """
+    fmt(fmt_project, start, expected)
+
+
+def test_classifier_gte(fmt: Fmt) -> None:
+    start = """
+    [project]
+    requires-python = ">=3.6"
+    """
+    expected = """
+    [project]
+    requires-python = ">=3.6"
+    classifiers = [
+      "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.6",
       "Programming Language :: Python :: 3.7",
       "Programming Language :: Python :: 3.8",
       "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Dear Bernát,

this patch aims to fix GH-137. ~~, which still satisfies the test suite, apparently not causing any other havoc.~~

The version comparison logic may need to be improved, because `_get_max_version_specifier` apparently only cares about the "maximum version", and not about the "minimum version". I.e., it does not handle the `>=` operator at all.

~~In this spirit, the fix is incorrect, but well, it resolves the issue ;].~~

With kind regards,
Andreas.
