### PR TITLE
Fix mypy by ignoring that pytest_mock does not provide type stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,8 @@ run.plugins = ["covdefaults"]
 [tool.mypy]
 show_error_codes = true
 strict = true
+
+[[tool.mypy.overrides]]
+
+module = ["pytest_mock"]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,8 @@ run.plugins = ["covdefaults"]
 [tool.mypy]
 show_error_codes = true
 strict = true
-
-[[tool.mypy.overrides]]
-
-module = ["pytest_mock"]
-ignore_missing_imports = true
+overrides = [
+  { module = [
+    "pytest_mock",
+  ], ignore_missing_imports = true },
+]


### PR DESCRIPTION
Without this, `mypy src/ tests/` fails.