### PR TITLE
Add test for indent at formatter test level

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Union
 
 from tomlkit.toml_document import TOMLDocument
 
 from pyproject_fmt.formatter.config import Config
 
-Fmt = Callable[[Callable[[TOMLDocument, Config], None], str, str], None]
+Fmt = Callable[[Callable[[TOMLDocument, Config], None], Union[str, Config], str], None]
 
 __all__ = [
     "Fmt",

--- a/tests/formatter/conftest.py
+++ b/tests/formatter/conftest.py
@@ -20,11 +20,11 @@ if TYPE_CHECKING:
 def fmt(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture, tmp_path: Path) -> Fmt:
     def _func(
         formatter: Callable[[TOMLDocument, Config], None],
-        start: str,
+        start: str | Config,
         expected: str,
     ) -> None:
         mocker.patch("pyproject_fmt.formatter._perform", formatter)
-        opts = Config(pyproject_toml=Path(), toml=dedent(start))
+        opts = Config(pyproject_toml=Path(), toml=dedent(start)) if isinstance(start, str) else start
         monkeypatch.chdir(tmp_path)
         result = format_pyproject(opts)
 

--- a/tests/formatter/test_build_system.py
+++ b/tests/formatter/test_build_system.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+from pathlib import Path
+from textwrap import dedent
 from typing import TYPE_CHECKING
 
+import pytest
+
 from pyproject_fmt.formatter.build_system import fmt_build_system
+from pyproject_fmt.formatter.config import Config
 
 if TYPE_CHECKING:
     from tests import Fmt
@@ -72,3 +77,29 @@ def test_build_backend_order(fmt: Fmt) -> None:
     """
 
     fmt(fmt_build_system, txt, expected)
+
+
+@pytest.mark.parametrize("indent", [0, 2, 4])
+def test_indent(fmt: Fmt, indent: int) -> None:
+    txt = """
+    [build-system]
+    requires = [
+    "A",
+    "B",
+    ]
+    backend-path = [
+    "C",
+    ]
+    """
+    expected = f"""
+    [build-system]
+    requires = [
+    {" " * indent}"A",
+    {" " * indent}"B",
+    ]
+    backend-path = [
+    {" " * indent}"C",
+    ]
+    """
+    config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=indent)
+    fmt(fmt_build_system, config, expected)

--- a/tests/formatter/test_project.py
+++ b/tests/formatter/test_project.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
+from pathlib import Path
 from subprocess import CalledProcessError
+from textwrap import dedent
 from typing import TYPE_CHECKING
 
 import pytest
 
+from pyproject_fmt.formatter.config import Config
 from pyproject_fmt.formatter.project import fmt_project
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from pytest_mock import MockerFixture
 
     from tests import Fmt
@@ -460,3 +461,47 @@ def test_classifier_tox_exe_bad(
     ]
     """
     fmt(fmt_project, start, start)
+
+
+@pytest.mark.parametrize("indent", [0, 2, 4])
+def test_indent(fmt: Fmt, indent: int) -> None:
+    txt = """
+    [project]
+    keywords = [
+      "A",
+    ]
+    dynamic = [
+      "B",
+    ]
+    classifiers = [
+      "C",
+    ]
+    dependencies = [
+      "D",
+    ]
+    [project.optional-dependencies]
+    docs = [
+      "E",
+    ]
+    """
+    expected = f"""
+    [project]
+    keywords = [
+    {" " * indent}"A",
+    ]
+    classifiers = [
+    {" " * indent}"C",
+    ]
+    dynamic = [
+    {" " * indent}"B",
+    ]
+    dependencies = [
+    {" " * indent}"D",
+    ]
+    [project.optional-dependencies]
+    docs = [
+    {" " * indent}"E",
+    ]
+    """
+    config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=indent)
+    fmt(fmt_project, config, expected)


### PR DESCRIPTION
This introduces a way to test formatting with a custom config. Once this, or another way to achieve that, is merged, new config options can be tested at this level, such as the one proposed in #141 .