### PR TITLE
chore: modernize Ruff config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,6 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.3
-    hooks:
-      - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:
@@ -39,7 +35,8 @@ repos:
     rev: v0.1.3
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix, --unsafe-fixes]
+        args: [--fix, --exit-non-zero-on-fix, --unsafe-fixes, --show-fixes]
+      - id: ruff-format
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,11 +63,9 @@ version.source = "vcs"
 [tool.ruff]
 line-length = 120
 src = ["src", ""]
-
-[tool.ruff.lint]
-select = ["ALL"]
-isort.required-imports = ["from __future__ import annotations"]
-ignore = [
+lint.select = ["ALL"]
+lint.isort.required-imports = ["from __future__ import annotations"]
+lint.ignore = [
   "ANN101",  # no type annotation for self
   "ANN401",  # allow Any as type annotation
   "D203",  # `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,12 @@ build.targets.sdist.include = ["/src", "/tests","tox.ini"]
 version.source = "vcs"
 
 [tool.ruff]
-select = ["ALL"]
 line-length = 120
-target-version = "py38"
-isort = {known-first-party = ["pyproject_fmt"], required-imports = ["from __future__ import annotations"]}
+src = ["src", ""]
+
+[tool.ruff.lint]
+select = ["ALL"]
+isort.required-imports = ["from __future__ import annotations"]
 ignore = [
   "ANN101",  # no type annotation for self
   "ANN401",  # allow Any as type annotation
@@ -72,7 +74,7 @@ ignore = [
   "D212",  # `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible
   "S104",  # Possible binding to all interface
 ]
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
   "S101",  # asserts allowed in tests...
   "FBT",  # don"t care about booleans as positional arguments in tests


### PR DESCRIPTION
Modernizing the Ruff config a bit. More things are in a .lint namespace now.
