### PR TITLE
Add option to skip normalising requirement versions

### DIFF
--- a/src/pyproject_fmt/cli.py
+++ b/src/pyproject_fmt/cli.py
@@ -22,11 +22,20 @@ class PyProjectFmtNamespace(Namespace):
     stdout: bool
     indent: int
     check: bool
+    preserve_dependency_versions: bool
 
     @property
     def configs(self) -> list[Config]:
         """:return: configurations"""
-        return [Config(toml, toml.read_text(encoding="utf-8"), self.indent) for toml in self.inputs]
+        return [
+            Config(
+                pyproject_toml=toml,
+                toml=toml.read_text(encoding="utf-8"),
+                indent=self.indent,
+                preserve_dependency_versions=self.preserve_dependency_versions,
+            )
+            for toml in self.inputs
+        ]
 
 
 def pyproject_toml_path_creator(argument: str) -> Path:
@@ -71,6 +80,8 @@ def _build_cli() -> ArgumentParser:
     group.add_argument("-s", "--stdout", action="store_true", help=msg)
     msg = "check and fail if any input would be formatted, printing any diffs"
     group.add_argument("--check", action="store_true", help=msg)
+    msg = "preserve dependency versions. For example do not change version 1.0.0 to 1"
+    group.add_argument("--preserve-dependency-versions", action="store_true", help=msg)
     parser.add_argument(
         "--indent",
         type=int,

--- a/src/pyproject_fmt/cli.py
+++ b/src/pyproject_fmt/cli.py
@@ -22,7 +22,7 @@ class PyProjectFmtNamespace(Namespace):
     stdout: bool
     indent: int
     check: bool
-    preserve_dependency_versions: bool
+    keep_full_version: bool
 
     @property
     def configs(self) -> list[Config]:
@@ -32,7 +32,7 @@ class PyProjectFmtNamespace(Namespace):
                 pyproject_toml=toml,
                 toml=toml.read_text(encoding="utf-8"),
                 indent=self.indent,
-                preserve_dependency_versions=self.preserve_dependency_versions,
+                keep_full_version=self.keep_full_version,
             )
             for toml in self.inputs
         ]
@@ -80,8 +80,8 @@ def _build_cli() -> ArgumentParser:
     group.add_argument("-s", "--stdout", action="store_true", help=msg)
     msg = "check and fail if any input would be formatted, printing any diffs"
     group.add_argument("--check", action="store_true", help=msg)
-    msg = "preserve dependency versions. For example do not change version 1.0.0 to 1"
-    group.add_argument("--preserve-dependency-versions", action="store_true", help=msg)
+    msg = "keep full dependency versions. For example do not change version 1.0.0 to 1"
+    group.add_argument("--keep-full-version", action="store_true", help=msg)
     parser.add_argument(
         "--indent",
         type=int,

--- a/src/pyproject_fmt/formatter/build_system.py
+++ b/src/pyproject_fmt/formatter/build_system.py
@@ -26,7 +26,7 @@ def fmt_build_system(parsed: TOMLDocument, conf: Config) -> None:
         normalize_pep508_array(
             requires_array=cast(Optional[Array], system.get("requires")),
             indent=conf.indent,
-            preserve_dependency_versions=conf.preserve_dependency_versions,
+            keep_full_version=conf.keep_full_version,
         )
         sorted_array(cast(Optional[Array], system.get("backend-path")), indent=conf.indent)
         order_keys(system, ("build-backend", "requires", "backend-path"))

--- a/src/pyproject_fmt/formatter/build_system.py
+++ b/src/pyproject_fmt/formatter/build_system.py
@@ -23,7 +23,11 @@ def fmt_build_system(parsed: TOMLDocument, conf: Config) -> None:
     """
     system = cast(Optional[Table], parsed.get("build-system"))
     if system is not None:
-        normalize_pep508_array(cast(Optional[Array], system.get("requires")), conf.indent)
+        normalize_pep508_array(
+            requires_array=cast(Optional[Array], system.get("requires")),
+            indent=conf.indent,
+            preserve_dependency_versions=conf.preserve_dependency_versions,
+        )
         sorted_array(cast(Optional[Array], system.get("backend-path")), indent=conf.indent)
         order_keys(system, ("build-backend", "requires", "backend-path"))
         ensure_newline_at_end(system)

--- a/src/pyproject_fmt/formatter/config.py
+++ b/src/pyproject_fmt/formatter/config.py
@@ -19,6 +19,7 @@ class Config:
     pyproject_toml: Path
     toml: str  #: the text to format
     indent: int = DEFAULT_INDENT  #: indentation to apply
+    preserve_dependency_versions: bool = False
 
 
 __all__ = [

--- a/src/pyproject_fmt/formatter/config.py
+++ b/src/pyproject_fmt/formatter/config.py
@@ -19,7 +19,7 @@ class Config:
     pyproject_toml: Path
     toml: str  #: the text to format
     indent: int = DEFAULT_INDENT  #: indentation to apply
-    preserve_dependency_versions: bool = False
+    keep_full_version: bool = False
 
 
 __all__ = [

--- a/src/pyproject_fmt/formatter/pep508.py
+++ b/src/pyproject_fmt/formatter/pep508.py
@@ -39,18 +39,25 @@ def _best_effort_string_repr(req: str) -> String:
         return toml_string(req)
 
 
-def normalize_pep508_array(requires_array: Array | None, indent: int) -> None:
+def normalize_pep508_array(requires_array: Array | None, indent: int, *, preserve_dependency_versions: bool) -> None:
     """
     Normalize a TOML array via PEP-508.
 
     :param requires_array: the input array
     :param indent: indentation level
+    :param preserve_dependency_versions: whether to preserve, and therefore not normalize, requirements
     """
     if requires_array is None:
         return
     # first normalize values
     for at in range(len(requires_array)):
-        normalized = _best_effort_string_repr(normalize_req(str(requires_array[at])))
+        initial_requirement_string = str(requires_array[at])
+        if preserve_dependency_versions:
+            final_requirement_string = initial_requirement_string
+        else:
+            final_requirement_string = normalize_req(initial_requirement_string)
+
+        normalized = _best_effort_string_repr(req=final_requirement_string)
         requires_array[at] = normalized
     # then sort
     sorted_array(requires_array, indent, key=lambda e: Requirement(e.text).name.lower())

--- a/src/pyproject_fmt/formatter/pep508.py
+++ b/src/pyproject_fmt/formatter/pep508.py
@@ -39,20 +39,20 @@ def _best_effort_string_repr(req: str) -> String:
         return toml_string(req)
 
 
-def normalize_pep508_array(requires_array: Array | None, indent: int, *, preserve_dependency_versions: bool) -> None:
+def normalize_pep508_array(requires_array: Array | None, indent: int, *, keep_full_version: bool) -> None:
     """
     Normalize a TOML array via PEP-508.
 
     :param requires_array: the input array
     :param indent: indentation level
-    :param preserve_dependency_versions: whether to preserve, and therefore not normalize, requirements
+    :param keep_full_version: whether to preserve, and therefore not normalize, requirements
     """
     if requires_array is None:
         return
     # first normalize values
     for at in range(len(requires_array)):
         initial_requirement_string = str(requires_array[at])
-        if preserve_dependency_versions:
+        if keep_full_version:
             final_requirement_string = initial_requirement_string
         else:
             final_requirement_string = normalize_req(initial_requirement_string)

--- a/src/pyproject_fmt/formatter/pep508.py
+++ b/src/pyproject_fmt/formatter/pep508.py
@@ -53,7 +53,6 @@ def normalize_pep508_array(requires_array: Array | None, indent: int, *, keep_fu
     for at in range(len(requires_array)):
         initial_requirement_string = str(requires_array[at])
         req_string = initial_requirement_string if keep_full_version else normalize_req(initial_requirement_string)
-
         normalized = _best_effort_string_repr(req=req_string)
         requires_array[at] = normalized
     # then sort

--- a/src/pyproject_fmt/formatter/pep508.py
+++ b/src/pyproject_fmt/formatter/pep508.py
@@ -52,11 +52,9 @@ def normalize_pep508_array(requires_array: Array | None, indent: int, *, keep_fu
     # first normalize values
     for at in range(len(requires_array)):
         initial_requirement_string = str(requires_array[at])
-        final_requirement_string = (
-            initial_requirement_string if keep_full_version else normalize_req(initial_requirement_string)
-        )
+        req_string = initial_requirement_string if keep_full_version else normalize_req(initial_requirement_string)
 
-        normalized = _best_effort_string_repr(req=final_requirement_string)
+        normalized = _best_effort_string_repr(req=req_string)
         requires_array[at] = normalized
     # then sort
     sorted_array(requires_array, indent, key=lambda e: Requirement(e.text).name.lower())

--- a/src/pyproject_fmt/formatter/pep508.py
+++ b/src/pyproject_fmt/formatter/pep508.py
@@ -52,10 +52,9 @@ def normalize_pep508_array(requires_array: Array | None, indent: int, *, keep_fu
     # first normalize values
     for at in range(len(requires_array)):
         initial_requirement_string = str(requires_array[at])
-        if keep_full_version:
-            final_requirement_string = initial_requirement_string
-        else:
-            final_requirement_string = normalize_req(initial_requirement_string)
+        final_requirement_string = (
+            initial_requirement_string if keep_full_version else normalize_req(initial_requirement_string)
+        )
 
         normalized = _best_effort_string_repr(req=final_requirement_string)
         requires_array[at] = normalized

--- a/src/pyproject_fmt/formatter/project.py
+++ b/src/pyproject_fmt/formatter/project.py
@@ -49,11 +49,19 @@ def fmt_project(parsed: TOMLDocument, conf: Config) -> None:  # noqa: C901
 
     sorted_array(cast(Optional[Array], project.get("classifiers")), indent=conf.indent, custom_sort="natsort")
 
-    normalize_pep508_array(cast(Optional[Array], project.get("dependencies")), conf.indent)
+    normalize_pep508_array(
+        requires_array=cast(Optional[Array], project.get("dependencies")),
+        indent=conf.indent,
+        preserve_dependency_versions=conf.preserve_dependency_versions,
+    )
     if "optional-dependencies" in project:
         opt_deps = cast(Table, project["optional-dependencies"])
         for value in opt_deps.values():
-            normalize_pep508_array(cast(Array, value), conf.indent)
+            normalize_pep508_array(
+                requires_array=cast(Array, value),
+                indent=conf.indent,
+                preserve_dependency_versions=conf.preserve_dependency_versions,
+            )
         order_keys(opt_deps, (), sort_key=lambda k: k[0])  # pragma: no branch
 
     for of_type in ("scripts", "gui-scripts", "entry-points", "urls"):

--- a/src/pyproject_fmt/formatter/project.py
+++ b/src/pyproject_fmt/formatter/project.py
@@ -52,7 +52,7 @@ def fmt_project(parsed: TOMLDocument, conf: Config) -> None:  # noqa: C901
     normalize_pep508_array(
         requires_array=cast(Optional[Array], project.get("dependencies")),
         indent=conf.indent,
-        preserve_dependency_versions=conf.preserve_dependency_versions,
+        keep_full_version=conf.keep_full_version,
     )
     if "optional-dependencies" in project:
         opt_deps = cast(Table, project["optional-dependencies"])
@@ -60,7 +60,7 @@ def fmt_project(parsed: TOMLDocument, conf: Config) -> None:  # noqa: C901
             normalize_pep508_array(
                 requires_array=cast(Array, value),
                 indent=conf.indent,
-                preserve_dependency_versions=conf.preserve_dependency_versions,
+                keep_full_version=conf.keep_full_version,
             )
         order_keys(opt_deps, (), sort_key=lambda k: k[0])  # pragma: no branch
 

--- a/tests/formatter/test_build_system.py
+++ b/tests/formatter/test_build_system.py
@@ -105,18 +105,18 @@ def test_indent(fmt: Fmt, indent: int) -> None:
     fmt(fmt_build_system, config, expected)
 
 
-def test_preserve_dependency_versions(fmt: Fmt) -> None:
+def test_keep_full_version(fmt: Fmt) -> None:
     txt = """
     [build-system]
     requires = [
       "A==1.0.0",
     ]
     """
-    config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=2, preserve_dependency_versions=True)
+    config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=2, keep_full_version=True)
     fmt(fmt_build_system, config, txt)
 
 
-def test_no_preserve_dependency_versions(fmt: Fmt) -> None:
+def test_no_keep_full_version(fmt: Fmt) -> None:
     txt = """
     [build-system]
     requires = [
@@ -129,5 +129,5 @@ def test_no_preserve_dependency_versions(fmt: Fmt) -> None:
       "A==1",
     ]
     """
-    config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=2, preserve_dependency_versions=False)
+    config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=2, keep_full_version=False)
     fmt(fmt_build_system, config, expected)

--- a/tests/formatter/test_build_system.py
+++ b/tests/formatter/test_build_system.py
@@ -105,7 +105,7 @@ def test_indent(fmt: Fmt, indent: int) -> None:
     fmt(fmt_build_system, config, expected)
 
 
-def test_keep_full_version(fmt: Fmt) -> None:
+def test_keep_full_version_on(fmt: Fmt) -> None:
     txt = """
     [build-system]
     requires = [
@@ -116,7 +116,7 @@ def test_keep_full_version(fmt: Fmt) -> None:
     fmt(fmt_build_system, config, txt)
 
 
-def test_no_keep_full_version(fmt: Fmt) -> None:
+def test_keep_full_version_off(fmt: Fmt) -> None:
     txt = """
     [build-system]
     requires = [

--- a/tests/formatter/test_build_system.py
+++ b/tests/formatter/test_build_system.py
@@ -103,3 +103,31 @@ def test_indent(fmt: Fmt, indent: int) -> None:
     """
     config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=indent)
     fmt(fmt_build_system, config, expected)
+
+
+def test_preserve_dependency_versions(fmt: Fmt) -> None:
+    txt = """
+    [build-system]
+    requires = [
+      "A==1.0.0",
+    ]
+    """
+    config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=2, preserve_dependency_versions=True)
+    fmt(fmt_build_system, config, txt)
+
+
+def test_no_preserve_dependency_versions(fmt: Fmt) -> None:
+    txt = """
+    [build-system]
+    requires = [
+      "A==1.0.0",
+    ]
+    """
+    expected = """
+    [build-system]
+    requires = [
+      "A==1",
+    ]
+    """
+    config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=2, preserve_dependency_versions=False)
+    fmt(fmt_build_system, config, expected)

--- a/tests/formatter/test_pep508.py
+++ b/tests/formatter/test_pep508.py
@@ -58,7 +58,7 @@ def test_normalize_pep508_array(indent: int) -> None:
     normalize_pep508_array(
         requires_array=cast(Array, dependencies),
         indent=indent,
-        preserve_dependency_versions=False,
+        keep_full_version=False,
     )
     assert dependencies == ["zzz>=1.1.1", "pytest==6"]
     expected_string = dedent(
@@ -72,7 +72,7 @@ def test_normalize_pep508_array(indent: int) -> None:
     assert dependencies.as_string() == expected_string
 
 
-def test_normalize_pep508_array_preserve_versions() -> None:
+def test_normalize_pep508_array_keep_versions() -> None:
     toml_document_string = """
         requirements = [
             "pytest==6.0.0",
@@ -83,6 +83,6 @@ def test_normalize_pep508_array_preserve_versions() -> None:
     normalize_pep508_array(
         requires_array=cast(Array, dependencies),
         indent=2,
-        preserve_dependency_versions=True,
+        keep_full_version=True,
     )
     assert dependencies == ["pytest==6.0.0"]

--- a/tests/formatter/test_pep508.py
+++ b/tests/formatter/test_pep508.py
@@ -55,7 +55,11 @@ def test_normalize_pep508_array(indent: int) -> None:
         """
     parsed = parse(toml_document_string)
     dependencies = parsed["requirements"]
-    normalize_pep508_array(requires_array=cast(Array, dependencies), indent=indent)
+    normalize_pep508_array(
+        requires_array=cast(Array, dependencies),
+        indent=indent,
+        preserve_dependency_versions=False,
+    )
     assert dependencies == ["zzz>=1.1.1", "pytest==6"]
     expected_string = dedent(
         f"""\
@@ -66,3 +70,19 @@ def test_normalize_pep508_array(indent: int) -> None:
         """,
     ).strip()
     assert dependencies.as_string() == expected_string
+
+
+def test_normalize_pep508_array_preserve_versions() -> None:
+    toml_document_string = """
+        requirements = [
+            "pytest==6.0.0",
+        ]
+        """
+    parsed = parse(toml_document_string)
+    dependencies = parsed["requirements"]
+    normalize_pep508_array(
+        requires_array=cast(Array, dependencies),
+        indent=2,
+        preserve_dependency_versions=True,
+    )
+    assert dependencies == ["pytest==6.0.0"]

--- a/tests/formatter/test_project.py
+++ b/tests/formatter/test_project.py
@@ -507,7 +507,7 @@ def test_indent(fmt: Fmt, indent: int) -> None:
     fmt(fmt_project, config, expected)
 
 
-def test_preserve_dependency_versions(fmt: Fmt) -> None:
+def test_keep_full_version(fmt: Fmt) -> None:
     txt = """
     [project]
     dependencies = [
@@ -518,11 +518,11 @@ def test_preserve_dependency_versions(fmt: Fmt) -> None:
       "B==2.0.0",
     ]
     """
-    config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=2, preserve_dependency_versions=True)
+    config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=2, keep_full_version=True)
     fmt(fmt_project, config, txt)
 
 
-def test_no_preserve_dependency_versions(fmt: Fmt) -> None:
+def test_no_keep_full_version(fmt: Fmt) -> None:
     txt = """
     [project]
     dependencies = [
@@ -543,5 +543,5 @@ def test_no_preserve_dependency_versions(fmt: Fmt) -> None:
       "B==2",
     ]
     """
-    config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=2, preserve_dependency_versions=False)
+    config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=2, keep_full_version=False)
     fmt(fmt_project, config, expected)

--- a/tests/formatter/test_project.py
+++ b/tests/formatter/test_project.py
@@ -507,7 +507,7 @@ def test_indent(fmt: Fmt, indent: int) -> None:
     fmt(fmt_project, config, expected)
 
 
-def test_keep_full_version(fmt: Fmt) -> None:
+def test_keep_full_version_on(fmt: Fmt) -> None:
     txt = """
     [project]
     dependencies = [
@@ -522,7 +522,7 @@ def test_keep_full_version(fmt: Fmt) -> None:
     fmt(fmt_project, config, txt)
 
 
-def test_no_keep_full_version(fmt: Fmt) -> None:
+def test_keep_full_version_off(fmt: Fmt) -> None:
     txt = """
     [project]
     dependencies = [

--- a/tests/formatter/test_project.py
+++ b/tests/formatter/test_project.py
@@ -505,3 +505,43 @@ def test_indent(fmt: Fmt, indent: int) -> None:
     """
     config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=indent)
     fmt(fmt_project, config, expected)
+
+
+def test_preserve_dependency_versions(fmt: Fmt) -> None:
+    txt = """
+    [project]
+    dependencies = [
+      "A==1.0.0",
+    ]
+    [project.optional-dependencies]
+    docs = [
+      "B==2.0.0",
+    ]
+    """
+    config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=2, preserve_dependency_versions=True)
+    fmt(fmt_project, config, txt)
+
+
+def test_no_preserve_dependency_versions(fmt: Fmt) -> None:
+    txt = """
+    [project]
+    dependencies = [
+      "A==1.0.0",
+    ]
+    [project.optional-dependencies]
+    docs = [
+      "B==2.0.0",
+    ]
+    """
+    expected = """
+    [project]
+    dependencies = [
+      "A==1",
+    ]
+    [project.optional-dependencies]
+    docs = [
+      "B==2",
+    ]
+    """
+    config = Config(pyproject_toml=Path(), toml=dedent(txt), indent=2, preserve_dependency_versions=False)
+    fmt(fmt_project, config, expected)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -158,7 +158,7 @@ def test_indent(tmp_path: Path, indent: int) -> None:
     assert output == dedent(expected)
 
 
-def test_keep_full_version(tmp_path: Path) -> None:
+def test_keep_full_version_cli(tmp_path: Path) -> None:
     start = """\
     [build-system]
     requires = [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -158,7 +158,7 @@ def test_indent(tmp_path: Path, indent: int) -> None:
     assert output == dedent(expected)
 
 
-def test_preserve_dependency_versions(tmp_path: Path) -> None:
+def test_keep_full_version(tmp_path: Path) -> None:
     start = """\
     [build-system]
     requires = [
@@ -176,7 +176,7 @@ def test_preserve_dependency_versions(tmp_path: Path) -> None:
     """
     pyproject_toml = tmp_path / "pyproject.toml"
     pyproject_toml.write_text(dedent(start))
-    args = [str(pyproject_toml), "--preserve-dependency-versions"]
+    args = [str(pyproject_toml), "--keep-full-version"]
     run(args)
     output = pyproject_toml.read_text()
     assert output == dedent(start)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -156,3 +156,27 @@ def test_indent(tmp_path: Path, indent: int) -> None:
     run(args)
     output = pyproject_toml.read_text()
     assert output == dedent(expected)
+
+
+def test_preserve_dependency_versions(tmp_path: Path) -> None:
+    start = """\
+    [build-system]
+    requires = [
+      "A==1.0.0",
+    ]
+
+    [project]
+    dependencies = [
+      "A==1.0.0",
+    ]
+    [project.optional-dependencies]
+    docs = [
+      "B==2.0.0",
+    ]
+    """
+    pyproject_toml = tmp_path / "pyproject.toml"
+    pyproject_toml.write_text(dedent(start))
+    args = [str(pyproject_toml), "--preserve-dependency-versions"]
+    run(args)
+    output = pyproject_toml.read_text()
+    assert output == dedent(start)


### PR DESCRIPTION
Using this option adds compatibility with Dependabot. Without this: Dependabot will bump a package to 1.3.0 and then pyproject-fmt will fail in CI because of the difference between the new and expected package version.

Fixes #141 .