### PR TITLE
Allow --check and --keep-full-version, they are not mutually exclusive

### DIFF
--- a/src/pyproject_fmt/cli.py
+++ b/src/pyproject_fmt/cli.py
@@ -81,7 +81,7 @@ def _build_cli() -> ArgumentParser:
     msg = "check and fail if any input would be formatted, printing any diffs"
     group.add_argument("--check", action="store_true", help=msg)
     msg = "keep full dependency versions. For example do not change version 1.0.0 to 1"
-    group.add_argument("--keep-full-version", action="store_true", help=msg)
+    parser.add_argument("--keep-full-version", action="store_true", help=msg)
     parser.add_argument(
         "--indent",
         type=int,


### PR DESCRIPTION
This was just an error by me.
I can add a test if wanted, but I think it isn't the most useful test.