### PR TITLE
fix: add more tools

### DIFF
--- a/src/pyproject_fmt/formatter/tools.py
+++ b/src/pyproject_fmt/formatter/tools.py
@@ -29,6 +29,7 @@ def fmt_tools(parsed: TOMLDocument, conf: Config) -> None:  # noqa: ARG001
     order = [
         # Build backends
         "poetry",
+        "pdm",
         "setuptools",
         "distutils",
         "setuptools_scm",
@@ -36,6 +37,10 @@ def fmt_tools(parsed: TOMLDocument, conf: Config) -> None:  # noqa: ARG001
         "flit",
         "scikit-build",
         "meson-python",
+        "maturin",
+        "whey",
+        "py-build-cmake",
+        "sphinx-theme-builder",
         # Builders
         "cibuildwheel",
         # Formatters and linters
@@ -44,16 +49,35 @@ def fmt_tools(parsed: TOMLDocument, conf: Config) -> None:  # noqa: ARG001
         "ruff",
         "isort",
         "flake8",
+        "pycln",
+        "nbqa",
         "pylint",
         "repo-review",
         "codespell",
         "docformatter",
+        "pydoclint",
+        "tomlsort",
+        "check-manifest",
+        "check-sdist",
+        "check-wheel-contents",
         # Testing
         "pytest",
         "pytest_env",
+        "pytest-enabler",
         "coverage",
+        # Runners
+        "doit",
+        "spin",
+        "tox",
+        # Releasers/bumpers
+        "bumpversion",
+        "jupyter-releaser",
+        "tbump",
+        "towncrier",
+        "vendoring",
         # Type checking
         "mypy",
+        "pyright",
     ]
     order_keys(tools, to_pin=order)
 

--- a/tests/formatter/test_tools.py
+++ b/tests/formatter/test_tools.py
@@ -45,13 +45,39 @@ def test_tools_ordering(fmt: Fmt) -> None:
     [tool.pylint]
     [tool.repo-review]
     a = 0
+    [tool.bumpversion]
+    [tool.check-manifest]
+    [tool.check-sdist]
+    [tool.check-wheel-contents]
+    [tool.doit]
     [tool.flit]
+    [tool.jupyter-releaser]
+    [tool.maturin]
+    [tool.mypy]
+    [tool.nbqa]
+    [tool.pdm]
+    [tool.py-build-cmake]
+    [tool.pycln]
+    [tool.pydoclint]
+    [tool.pyright]
+    [tool.pytest-enabler]
+    [tool.pytest_env]
+    [tool.sphinx-theme-builder]
+    [tool.spin]
+    [tool.tbump]
+    [tool.tomlsort]
+    [tool.towncrier]
+    [tool.tox]
+    [tool.vendoring]
+    [tool.whey]
     """
     expected = """
     [tool.poetry]
     name = "a"
     [tool.poetry.scripts]
     version = "1"
+    [tool.pdm]
+
     [tool.setuptools]
     a.b = 0
 
@@ -72,6 +98,14 @@ def test_tools_ordering(fmt: Fmt) -> None:
     [tool.meson-python]
     a = 0
 
+    [tool.maturin]
+
+    [tool.whey]
+
+    [tool.py-build-cmake]
+
+    [tool.sphinx-theme-builder]
+
     [tool.cibuildwheel]
     a = 0
 
@@ -86,6 +120,10 @@ def test_tools_ordering(fmt: Fmt) -> None:
 
     [tool.flake8]
 
+    [tool.pycln]
+
+    [tool.nbqa]
+
     [tool.pylint]
 
     [tool.repo-review]
@@ -96,11 +134,45 @@ def test_tools_ordering(fmt: Fmt) -> None:
     [tool.docformatter]
     c = 0
 
+    [tool.pydoclint]
+
+    [tool.tomlsort]
+
+    [tool.check-manifest]
+
+    [tool.check-sdist]
+
+    [tool.check-wheel-contents]
+
     [tool.pytest]
     a = 0
 
+    [tool.pytest_env]
+
+    [tool.pytest-enabler]
+
     [tool.coverage]
     a = 0
+
+    [tool.doit]
+
+    [tool.spin]
+
+    [tool.tox]
+
+    [tool.bumpversion]
+
+    [tool.jupyter-releaser]
+
+    [tool.tbump]
+
+    [tool.towncrier]
+
+    [tool.vendoring]
+
+    [tool.mypy]
+
+    [tool.pyright]
         """
     fmt(fmt_tools, content, expected)
 


### PR DESCRIPTION
I scanned most of the repos that I have downloaded at some point for their pyproject.toml tool sections, then looked at every unique tool key. I've added the ones that make sense here (a few projects have their own tool section, but it's not clear it's useful for anyone else, and there were a couple of very general sounding ones that I wasn't sure about like `tool.aliases` in `pylint` that I left off). I also added a couple of other ones I'm familiar with.