### PR TITLE
Fix the "Release to PyPI" workflow and add check-jsonschema as a pre-commit hook to prevent future errors

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@ name: check
 on:
   workflow_dispatch:
   push:
-    branches: "main"
+    branches: ["main"]
     tags-ignore: ["**"]
   pull_request:
   schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - name: Setup python to build package
         uses: actions/setup-python@v5
-        cache: "pip"
         with:
+          cache: "pip"
           python-version: "3.12"
       - name: Install build
         run: python -m pip install build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,8 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.27.3
+    hooks:
+      - id: check-github-workflows
+        args: ["--verbose"]


### PR DESCRIPTION
The 1.6.0 release failed to go out because of an error in the `release.yml`  workflow.