### PR TITLE
Reintroduce public API (previously removed in 2.0)

### DIFF
--- a/src/pyproject_fmt/__init__.py
+++ b/src/pyproject_fmt/__init__.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from ._api import Settings, SettingsError, format_toml
 from ._version import __version__
 
 __all__ = [
+    "Settings",
+    "SettingsError",
     "__version__",
+    "format_toml",
 ]

--- a/src/pyproject_fmt/__main__.py
+++ b/src/pyproject_fmt/__main__.py
@@ -7,8 +7,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, Sequence
 
-from pyproject_fmt_rust import format_toml
-
+from pyproject_fmt._api import format_toml
 from pyproject_fmt.cli import cli_args
 
 if TYPE_CHECKING:

--- a/src/pyproject_fmt/_api.py
+++ b/src/pyproject_fmt/_api.py
@@ -1,0 +1,90 @@
+"""Wrapper for ``pyproject_fmt_rust`` adding default and TOML configuration."""
+
+from __future__ import annotations
+
+import dataclasses
+import sys
+from typing import TYPE_CHECKING, Any
+
+import pyproject_fmt_rust
+
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+    from typing import Self
+
+    import tomllib
+else:  # pragma: <3.11 cover
+    import tomli as tomllib
+
+    if TYPE_CHECKING:  # pragma: no cover
+        from typing_extensions import Self
+
+
+class SettingsError(ValueError):
+    """Exception for invalid ``pyproject-fmt`` configurations."""
+
+
+@dataclasses.dataclass
+class Settings:
+    """
+    Dataclass for formatting parameters.
+
+    Attributes correspond to options in the CLI.
+    """
+
+    column_width: int = 1
+    indent: int = 2
+    keep_full_version: bool = False
+    max_supported_python: tuple[int, int] = (3, 12)
+    min_supported_python: tuple[int, int] = (3, 8)
+
+    def read_toml(self, pyproject_toml: str) -> Self:
+        """Create a copy with attributes overwritten by the TOML configuration."""
+        return self._read_toml(tomllib.loads(pyproject_toml))
+
+    def _read_toml(self, pyproject: dict[str, Any], exc: type[Exception] = SettingsError) -> Self:
+        copy = self.__class__(**dataclasses.asdict(self))
+
+        if "tool" in pyproject and "pyproject-fmt" in pyproject["tool"]:
+            for key, entry in pyproject["tool"]["pyproject-fmt"].items():
+                if key == "column_width":
+                    copy.column_width = int(entry)
+                elif key == "indent":
+                    copy.indent = int(entry)
+                elif key == "keep_full_version":
+                    copy.keep_full_version = bool(entry)
+                elif key == "max_supported_python":
+                    copy.max_supported_python = self._version_argument(entry, exc)
+
+        return copy
+
+    @staticmethod
+    def _version_argument(got: str, exc: type[Exception] = SettingsError) -> tuple[int, int]:
+        # "Protected" method: private for the outside world, but used internally.
+        parts = got.split(".")
+        if len(parts) != 2:  # noqa: PLR2004
+            msg = f"invalid version: {got}, must be e.g. 3.12"
+            raise exc(msg)
+        try:
+            return int(parts[0]), int(parts[1])
+        except ValueError as e:
+            msg = f"invalid version: {got} due {e!r}, must be e.g. 3.12"
+            raise exc(msg) from e
+
+    def _as_native(self) -> pyproject_fmt_rust.Settings:
+        # "Protected" method: private for the outside world, but used internally.
+        return pyproject_fmt_rust.Settings(
+            column_width=self.column_width,
+            indent=self.indent,
+            keep_full_version=self.keep_full_version,
+            max_supported_python=self.max_supported_python,
+            min_supported_python=self.min_supported_python,
+        )
+
+
+def format_toml(text: str, settings: Settings | None = None) -> str:
+    """Format the given ``pyproject.toml`` text."""
+    config = (settings or Settings()).read_toml(text)
+    return pyproject_fmt_rust.format_toml(text, config._as_native())  # noqa: SLF001
+
+
+__all__ = ["Settings", "SettingsError", "format_toml"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pyproject_fmt import Settings, SettingsError, format_toml
+
+
+def test_default_config() -> None:
+    txt = """\
+    [project]
+    keywords = ["A"]
+    classifiers = ["Programming Language :: Python :: 3 :: Only"]
+    """
+    expected = dedent(
+        """\
+        [project]
+        keywords = [
+          "A",
+        ]
+        classifiers = [
+          "Programming Language :: Python :: 3 :: Only",
+          "Programming Language :: Python :: 3.8",
+          "Programming Language :: Python :: 3.9",
+          "Programming Language :: Python :: 3.10",
+          "Programming Language :: Python :: 3.11",
+          "Programming Language :: Python :: 3.12",
+        ]
+        """
+    )
+    got = format_toml(txt)
+    assert got == expected
+
+
+def test_pyproject_toml_config() -> None:
+    txt = """\
+    [project]
+    keywords = [
+      "A",
+    ]
+    classifiers = [
+      "Programming Language :: Python :: 3 :: Only",
+    ]
+    dynamic = [
+      "B",
+    ]
+    dependencies = [
+      "requests>=2.0",
+    ]
+
+    [tool.pyproject-fmt]
+    column_width = 20
+    indent = 4
+    keep_full_version = true
+    max_supported_python = "3.10"
+    ignore_extra = true
+    """
+
+    expected = dedent(
+        """\
+        [project]
+        keywords = [
+            "A",
+        ]
+        classifiers = [
+            "Programming Language :: Python :: 3 :: Only",
+            "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
+        ]
+        dynamic = [
+            "B",
+        ]
+        dependencies = [
+            "requests>=2.0",
+        ]
+
+        [tool.pyproject-fmt]
+        column_width = 20
+        indent = 4
+        keep_full_version = true
+        max_supported_python = "3.10"
+        ignore_extra = true
+        """
+    )
+    got = format_toml(txt, Settings(min_supported_python=(3, 9)))
+    assert got == expected
+
+
+@pytest.mark.parametrize("version", ["3", "3.X"])
+def test_invalid_version(version: str) -> None:
+    with pytest.raises(SettingsError, match=f"invalid version: {version}"):
+        Settings._version_argument(version)  # noqa: SLF001


### PR DESCRIPTION
This PR re-introduces an public Python API.
The API was changed to be modelled after `pyproject-fmt-rust`, but it adds conveniences such as default configuration values + the ability for reading configuration from the file being formatted.

The motivation and use case are described in #3 and https://github.com/tox-dev/pyproject-fmt/issues/200#issuecomment-2108530014.

In terms of implementation, some functionalities from the `cli` module were moved/refactored into the new module.

Please take this as just an example on how things could work (and I am sure that there is a bunch of bike-shedding to be discussed). Please also feel free to close this PR if the approach is too far from what is acceptable, and also please feel free to steal parts of the PR to create something different.