### PR TITLE
Allow for reading TOML files from stdin.

### DIFF
--- a/src/pyproject_fmt/__main__.py
+++ b/src/pyproject_fmt/__main__.py
@@ -38,7 +38,7 @@ def _handle_one(config: Config) -> bool:
     formatted = format_toml(config.toml, config.settings)
     before = config.toml
     changed = before != formatted
-    if config.stdout:  # stdout just prints new format to stdout
+    if config.pyproject_toml is None or config.stdout:  # when reading from stdin or writing to stdout, print new format
         print(formatted, end="")  # noqa: T201
         return changed
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import os
 import sys
 from importlib.metadata import version
@@ -12,6 +13,8 @@ from pyproject_fmt.cli import cli_args
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from pytest_mock import MockerFixture
 
 
 def test_cli_version(capsys: pytest.CaptureFixture[str]) -> None:
@@ -63,6 +66,14 @@ def test_cli_inputs_ok(tmp_path: Path) -> None:
         paths.append(path)
     result = cli_args([*map(str, paths)])
     assert len(result) == 3
+
+
+def test_cli_pyproject_toml_stdin(mocker: MockerFixture) -> None:
+    mocker.patch("pyproject_fmt.cli.sys.stdin", io.StringIO(""))
+    result = cli_args(["-"])
+    assert len(result) == 1
+    assert result[0].pyproject_toml is None
+    assert not result[0].toml
 
 
 def test_cli_pyproject_toml_not_exists(


### PR DESCRIPTION
When the input filename is '-', read the toml from stdin and output to stdout.

Closes #238.