### PR TITLE
Remove `tool.ruff.target_version`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ build.targets.sdist.include = [
 version.source = "vcs"
 
 [tool.ruff]
-target-version = "py39"
 line-length = 120
 format.preview = true
 format.docstring-code-line-length = 100


### PR DESCRIPTION
> If you're already using a `pyproject.toml` file, we recommend `project.requires-python` instead, as it's based on Python packaging standards, and will be respected by other tools.

https://docs.astral.sh/ruff/settings/#target-version