### PR TITLE
Remove persist-credentials: false and git remote workaround

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: 🛒 Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
       - name: 🔧 Configure git
         run: |
           git config --global user.name 'Github Actions'
@@ -51,7 +49,6 @@ jobs:
       - name: 🚀 Push changes
         if: github.ref == 'refs/heads/main' && steps.commit.outputs.version
         run: |
-          git remote set-url origin https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}
           git push origin HEAD:refs/heads/main
           git push origin --tags -f
       - name: 🎉 Create GitHub release


### PR DESCRIPTION
## Summary
- Remove `persist-credentials: false` from the checkout step
- Remove the `git remote set-url` workaround that was added to compensate for stripped credentials
- The checkout action's default credential persistence is sufficient for `git push` when the job has `contents: write` permission