### PR TITLE
Use Python 3.15

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,7 +26,7 @@ jobs:
           enable-cache: "false"
       - name: 🪞 Run pre-commit-mirror-maker
         run: >-
-          uvx -p 3.14 --from pre-commit-mirror-maker pre-commit-mirror . --language=python --package-name=pyproject-fmt --files-regex '(^|/)pyproject\.toml$'
+          uvx -p 3.15 --from pre-commit-mirror-maker pre-commit-mirror . --language=python --package-name=pyproject-fmt --files-regex '(^|/)pyproject\.toml$'
       - name: 📝 Update README with current version
         run: |
           VERSION=$(cat .version)


### PR DESCRIPTION
Bump the interpreter used to run `pre-commit-mirror-maker` from 3.14 to 3.15, mirroring 69b77b8 which did the same for 3.13 -> 3.14.

Python 3.15 is still in beta (currently 3.15.0b3). `uv` resolves it without an explicit prerelease flag, so no `allow-prereleases` or `-dev` suffix is needed.

Note this repo is the pre-commit mirror, so this pin only affects the interpreter that regenerates the hook metadata; it is not test coverage of pyproject-fmt itself.